### PR TITLE
Verbosity control

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,5 @@
 ^docs$
 ^pkgdown$
 ^codemeta\.json$
+^doc$
+^Meta$

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 *.excalidraw
 inst/doc
 docs
+/doc/
+/Meta/

--- a/R/create_object_list.R
+++ b/R/create_object_list.R
@@ -40,7 +40,7 @@ create_object_list <- function(df_current, df_previous, datetime_variable) {
 
   # Check if `datetime_variable` is in both `df_current` and `df_previous`
   if (!datetime_variable %in% names(df_current) || !datetime_variable %in% names(df_previous)) {
-    stop(
+    cli::cli_abort(
       "`datetime_variable` must be present in both `df_current` and `df_previous`"
     )
   }
@@ -76,7 +76,7 @@ create_object_list <- function(df_current, df_previous, datetime_variable) {
   # Creating a feedback message depending on the waldo object's output
   # First checking if there are new rows at all:
   if (nrow(df_current_new_rows) == 0) {
-    stop(
+    cli::cli_abort(
       "There are no new rows. Check '",
       deparse(substitute(df_current)),
       "' is your most recent data, and '",

--- a/README.Rmd
+++ b/README.Rmd
@@ -23,7 +23,7 @@ knitr::opts_chunk$set(
 
 The goal of butterfly is to aid in the quality assurance of continually updating and overwritten time-series data, where we expect new values over time, but want to ensure previous data remains unchanged. 
 
-```{r butterfly_diagram, echo=FALSE, out.width="100%", fig.cap=""}
+```{r butterfly_diagram, echo=FALSE, out.width="100%", fig.cap="An illustration of continually updating timeseries data where a previous value unexpectedly changes."}
 knitr::include_graphics("man/figures/README-butterfly_diagram.png")
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,15 @@ The goal of butterfly is to aid in the quality assurance of continually
 updating and overwritten time-series data, where we expect new values
 over time, but want to ensure previous data remains unchanged.
 
-<img src="man/figures/README-butterfly_diagram.png" width="100%" />
+<div class="figure">
+
+<img src="man/figures/README-butterfly_diagram.png" alt="An illustration of continually updating timeseries data where a previous value unexpectedly changes." width="100%" />
+<p class="caption">
+An illustration of continually updating timeseries data where a previous
+value unexpectedly changes.
+</p>
+
+</div>
 
 Data previously recorded could change for a number of reasons, such as
 discovery of an error in model code, a change in methodology or

--- a/vignettes/butterfly.Rmd
+++ b/vignettes/butterfly.Rmd
@@ -16,7 +16,7 @@ knitr::opts_chunk$set(
 
 The goal of butterfly is to aid in the quality assurance of continually updating and overwritten time-series data, where we expect new values over time, but want to ensure previous data remains unchanged. 
 
-```{r butterfly_diagram, echo=FALSE, out.width="100%", fig.cap=""}
+```{r butterfly_diagram, echo=FALSE, out.width="100%", fig.cap="An illustration of continually updating timeseries data where a previous value unexpectedly changes."}
 knitr::include_graphics("img/butterfly_diagram_light.png")
 ```
 
@@ -121,7 +121,7 @@ This dataset is entirely fictional, and merely included to aid demonstrating but
 
 ## A note on controlling verbosity
 
-Although verbosity is mostly the purpose if this package, **should** you wish to silence messages and warnings, you can do so with `options(rlib_message_verbosity = "quiet")` and options `(rlib_warning_verbosity = "quiet")`.
+<!-- Although verbosity is mostly the purpose if this package, **should** you wish to silence messages and warnings, you can do so with `options(rlib_message_verbosity = "quiet")` and options `(rlib_warning_verbosity = "quiet")`. -->
 
 ## Incorporating in data pipeline
 

--- a/vignettes/butterfly.Rmd
+++ b/vignettes/butterfly.Rmd
@@ -119,6 +119,10 @@ butterflycount
 
 This dataset is entirely fictional, and merely included to aid demonstrating butterfly's functionality.
 
+## A note on controlling verbosity
+
+Although verbosity is mostly the purpose if this package, **should** you wish to silence messages and warnings, you can do so with `options(rlib_message_verbosity = "quiet")` and options `(rlib_warning_verbosity = "quiet")`.
+
 ## Incorporating in data pipeline
 
 Examples of using applying butterfly in a pipeline.


### PR DESCRIPTION
Replacing some `stop()` functions with `cli::abort()` for consistency.

Adding documentation on version control.

Adding figure alt text to captions.

Closes #15 